### PR TITLE
fix: logic for detecting slotable content

### DIFF
--- a/packages/slotify/src/slotify.js
+++ b/packages/slotify/src/slotify.js
@@ -275,12 +275,11 @@ export const Slotify = superclass =>
       let slotableContent;
       if (slotName === 'default') {
         // get all nodes outside s-root that aren't assigned to another slot
-        slotableContent = Array.from(this.childNodes).filter(
-          n =>
-            n.tagName &&
-            n.tagName.toLowerCase() !== 's-root' &&
-            n.getAttribute('slot') === null,
-        );
+        slotableContent = Array.from(this.childNodes).filter(n => {
+          // only Element nodes can have tagNames and attributes. if the node is something else, we can
+          // safely assume that it should be moved into the default slot.
+          return n.nodeType !== Node.ELEMENT_NODE || (n.tagName.toLowerCase() !== 's-root' && n.getAttribute('slot') === null);
+        });
       } else {
         slotableContent = Array.from(
           this.querySelectorAll(`*[slot='${slotName}']`),


### PR DESCRIPTION
Previously, `hasSlotableContent` would only detect slotted content if it was an Element node and would returned `false` if the default slot contained only a Text node (e.g. plain text not wrapped in an HTML element).